### PR TITLE
First jump workarounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore saved route files
 *.csv
 
-# Ignore pyc files
+# Ignore compiles python files
+*.pyo
 *.pyc

--- a/README.md
+++ b/README.md
@@ -26,4 +26,8 @@ Fly dangerous! o7
 
 
 ## Known Issues
-At the moment, plotting a route while the game is running, and which begins from the system you're currently in, doesn't update your "next waypoint". If you're in that situation, logging off and back in should "wake up" the plugin.
+At the moment, plotting a route while the game is running, and which begins from the system you're currently in, doesn't update your "next waypoint". If you're in that situation, a couple of solutions are available:
+
+* Performing a FSS Discovery Scan
+* Go in our out of Supercruise
+* Logging back in and out while EDMC is already running.

--- a/load.py
+++ b/load.py
@@ -17,6 +17,7 @@ this.next_wp_label = "Next waypoint: "
 this.parent = None
 this.save_route_path = ""
 
+
 def plugin_start():
     if sys.platform == 'win32':
         this.save_route_path = os.path.expandvars(r'%LOCALAPPDATA%\EDMarketConnector\plugins\SpanshRouter\route.csv')
@@ -41,8 +42,10 @@ def plugin_stop():
         with open(this.save_route_path, 'w') as csvfile:
             csvfile.write('\n'.join(this.route))
 
+
 def update_gui():
     this.waypoint_btn["text"] = this.next_wp_label + this.next_stop
+
 
 def copy_waypoint(self=None):
     if sys.platform == "win32":
@@ -52,6 +55,7 @@ def copy_waypoint(self=None):
     else:
         command = subprocess.Popen(["echo", "-n", this.next_stop], stdout=subprocess.PIPE)
         subprocess.Popen(["xclip", "-selection", "c"], stdin=command.stdout)
+
 
 def new_route(self=None):
     filename = filedialog.askopenfilename(filetypes = (("csv files", "*.csv"),))    # show an "Open" dialog box and return the path to the selected file
@@ -70,6 +74,7 @@ def new_route(self=None):
         copy_waypoint()
         update_gui()
 
+
 def update_route():
     del(this.route[1])
     if this.route.__len__() == 0:
@@ -82,6 +87,7 @@ def update_route():
         update_gui()
         copy_waypoint(this.parent)
 
+
 def journal_entry(cmdr, is_beta, system, station, entry, state):
     if (entry['event'] == 'FSDJump' or entry['event'] == 'Location') and entry["StarSystem"] == this.next_stop:
         update_route()
@@ -90,8 +96,8 @@ def plugin_app(parent):
     this.parent = parent
 
     this.frame = tk.Frame(parent)
-    this.waypoint_btn = tk.Button(frame, text= this.next_wp_label + this.next_stop)
-    this.upload_route_btn = tk.Button(frame, text= "Upload new route")
+    this.waypoint_btn = tk.Button(this.frame, text=this.next_wp_label + this.next_stop)
+    this.upload_route_btn = tk.Button(this.frame, text="Upload new route")
 
     this.waypoint_btn.bind("<ButtonRelease-1>", copy_waypoint)
     this.upload_route_btn.bind("<ButtonRelease-1>", new_route)

--- a/load.py
+++ b/load.py
@@ -91,6 +91,11 @@ def update_route():
 def journal_entry(cmdr, is_beta, system, station, entry, state):
     if (entry['event'] == 'FSDJump' or entry['event'] == 'Location') and entry["StarSystem"] == this.next_stop:
         update_route()
+    elif entry['event'] in ['SupercruiseEntry', 'SupercruiseExit'] and entry['StarSystem'] == this.next_stop:
+        update_route()
+    elif entry['event'] == 'FSSDiscoveryScan' and entry['SystemName'] == this.next_stop:
+        update_route()
+
 
 def plugin_app(parent):
     this.parent = parent


### PR DESCRIPTION
This adds a couple of methods to update the route that do not require you to log off and on again:

* Perform a FSS Discovery Scan
* Jump in or out of supercruise